### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+cube/swiss/build/
+cube/swiss/dist/
+
+cube/actionreplay/SDLOADER.BIN
+
+pc/usbgecko/swissserver
+pc/usbgecko/swissserver.exe
+pc/usbgecko/core
+pc/usbgecko/core.*
+
+*.dol
+*.elf
+*.o
+*.d
+*.map
+*.gcm


### PR DESCRIPTION
Helps keeping build output out of the way when committing
It may be incomplete but I think I got most of it from the clean scripts and my own tests. Libfat not covered here as I have another PR planned for that.