### PR TITLE
dol2gci: Strip entire path from GCI name

### DIFF
--- a/buildtools/dol2gci.cpp
+++ b/buildtools/dol2gci.cpp
@@ -168,11 +168,11 @@ int main (int argc, char * const argv[])
 	// strip path from filename, looking for forward and backslash
 	string name = argv[1];
 	unsigned int i;
-	i = name.find('/');
+	i = name.rfind('/');
 	if (i!=string::npos) {
 		name = name.substr(i+1);
 	}
-	i = name.find('\\');
+	i = name.rfind('\\');
 	if (i!=string::npos) {
 		name = name.substr(i+1);
 	}


### PR DESCRIPTION
The old code was removing just the first directory, which was bad news for anyone using absolute paths.

This commit does not update the prebuilt dol2gci binaries.