### PR TITLE
fix typo in 2^13-1

### DIFF
--- a/buildtools/dol2gci.cpp
+++ b/buildtools/dol2gci.cpp
@@ -193,7 +193,7 @@ int main (int argc, char * const argv[])
 	// calculate overal size
 	int icon_size = ((sizeof(dol_icon) + 31) & ~31);
 	int data_size = 64 + icon_size + dol_size;
-	int data_blocks = (data_size + 8291) / 8192;
+	int data_blocks = (data_size + 8191) / 8192;
 	
 	// create GCI file
 	int gci_size = 64 + data_blocks * 8192;


### PR DESCRIPTION
this can save one 8K block in some cases