### PR TITLE
#654 - Standardise and tidy up deviceHandler init return codes.

### DIFF
--- a/cube/swiss/include/swiss.h
+++ b/cube/swiss/include/swiss.h
@@ -79,7 +79,7 @@ extern bool select_dest_dir(file_handle* directory, file_handle* selection);
 
 typedef struct {
 	int debugUSB; // Debug prints over USBGecko
-	int hasDVDDrive;	// 0 if none, 1 if something, 2 if present and init'd from cold boot
+	int hasDVDDrive;	// 0 if none, 1 if something
 	int exiSpeed;
 	int uiVMode;	// What mode to force Swiss into
 	int gameVMode;	// What mode to force a Game into

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -108,7 +108,7 @@ bool config_set_device() {
 	// If we're not using this device already, init it.
 	if(devices[DEVICE_CONFIG] != devices[DEVICE_CUR]) {
 		print_gecko("Save device is not current, current is (%s)\r\n", devices[DEVICE_CUR] == NULL ? "NULL":devices[DEVICE_CUR]->deviceName);
-		if(!devices[DEVICE_CONFIG]->init(devices[DEVICE_CONFIG]->initial)) {
+		if(devices[DEVICE_CONFIG]->init(devices[DEVICE_CONFIG]->initial)) {
 			print_gecko("Save device failed to init\r\n");
 			deviceHandler_setStatEnabled(1);
 			return false;

--- a/cube/swiss/source/devices/deviceHandler.c
+++ b/cube/swiss/source/devices/deviceHandler.c
@@ -68,13 +68,6 @@ void deviceHandler_setAllDevicesAvailable() {
 	}
 }
 
-int deviceHandler_test(DEVICEHANDLER_INTERFACE *device) {
-	deviceHandler_setStatEnabled(0);
-	int ret = device->init(device->initial);
-	deviceHandler_setStatEnabled(1);
-	return ret;
-}
-
 DEVICEHANDLER_INTERFACE* getDeviceByUniqueId(u8 id) {
 	for(int i = 0; i < MAX_DEVICES; i++) {
 		if(allDevices[i] != NULL && allDevices[i]->deviceUniqueId == id) {

--- a/cube/swiss/source/devices/deviceHandler.h
+++ b/cube/swiss/source/devices/deviceHandler.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <gctypes.h>
 #include <stdio.h>
+#include <errno.h>
 #include "ff.h"
 #include "diskio.h"
 #include "wode/WodeInterface.h"
@@ -86,6 +87,7 @@ typedef s32 (* _fn_renameFile)(file_handle*, char*);
 typedef s32 (* _fn_setupFile)(file_handle*, file_handle*, int);
 typedef s32 (* _fn_deinit)(file_handle*);
 typedef u32 (* _fn_emulated)(void);
+typedef char* (* _fn_status)(file_handle*);
 
 // Device features
 #define FEAT_READ				0x1
@@ -162,6 +164,7 @@ struct DEVICEHANDLER_STRUCT {
 	_fn_setupFile	setupFile;
 	_fn_deinit		deinit;
 	_fn_emulated	emulated;
+	_fn_status		status;
 } ;
 
 typedef struct DEVICEHANDLER_STRUCT DEVICEHANDLER_INTERFACE;
@@ -173,6 +176,13 @@ enum DEVICE_SLOTS {
 	DEVICE_CONFIG,
 	DEVICE_PATCHES,
 	MAX_DEVICE_SLOTS
+};
+
+// Common error types
+enum DEV_ERRORS {
+	E_NONET=1,
+	E_CHECKCONFIG,
+	E_CONNECTFAIL
 };
 
 #include "devices/dvd/deviceHandler-DVD.h"
@@ -197,7 +207,6 @@ extern void deviceHandler_setAllDevicesAvailable();
 extern DEVICEHANDLER_INTERFACE* allDevices[MAX_DEVICES];
 extern DEVICEHANDLER_INTERFACE* devices[MAX_DEVICE_SLOTS];
 
-extern int deviceHandler_test(DEVICEHANDLER_INTERFACE *device);
 extern DEVICEHANDLER_INTERFACE* getDeviceByUniqueId(u8 id);
 extern DEVICEHANDLER_INTERFACE* getDeviceByLocation(u32 location);
 extern DEVICEHANDLER_INTERFACE* getDeviceFromPath(char *path);

--- a/cube/swiss/source/devices/dvd/deviceHandler-DVD.c
+++ b/cube/swiss/source/devices/dvd/deviceHandler-DVD.c
@@ -23,7 +23,7 @@
 #define OFFSET_SET    1
 
 file_handle initial_DVD =
-	{ "dvd:/",     // directory
+{ "dvd:/",     // directory
 	  0ULL,     // fileBase (u64)
 	  0,        // offset
 	  0,        // size
@@ -132,7 +132,7 @@ char *dvd_error_str()
 
 int initialize_disc(u32 streaming) {
 	int patched = NORMAL_MODE;
-	uiDrawObj_t* progBar = DrawPublish(DrawProgressBar(true, 0, "DVD Is Initializing"));
+	uiDrawObj_t* progBar = DrawPublish(DrawProgressBar(true, 0, "DVD Initializing"));
 	if(is_gamecube())
 	{
 		// Reset WKF hard to allow for a real disc to be read if SD is removed
@@ -158,13 +158,8 @@ int initialize_disc(u32 streaming) {
 				drive_status = DEBUG_MODE;
 			}
 		}
-		else if((dvd_get_error()>>24) == 1) {  // Lid is open, tell the user!
+		else if((dvd_get_error()>>24) == 1) {  // Lid is open
 			DrawDispose(progBar);
-			sprintf(txtbuffer, "Error %s. Press A.",dvd_error_str());
-			uiDrawObj_t *msgBox = DrawMessageBox(D_FAIL, txtbuffer);
-			DrawPublish(msgBox);
-			wait_press_A();
-			DrawDispose(msgBox);
 			return DRV_ERROR;
 		}
 		if((streaming == ENABLE_AUDIO) || (streaming == DISABLE_AUDIO)) {
@@ -185,17 +180,11 @@ int initialize_disc(u32 streaming) {
 		}
 	}
 	dvd_read_id();
-	if(dvd_get_error()) { //no disc, or no game id.
-		DrawDispose(progBar);
-		sprintf(txtbuffer, "Error: %s",dvd_error_str());
-		uiDrawObj_t *msgBox = DrawMessageBox(D_FAIL, txtbuffer);
-		DrawPublish(msgBox);
-		wait_press_A();
-		dvd_reset();	// for good measure
-		DrawDispose(msgBox);
+	DrawDispose(progBar);
+	if(dvd_get_error()) {
 		return DRV_ERROR;
 	}
-	DrawDispose(progBar);
+			
 	return patched;
 }
 
@@ -540,16 +529,11 @@ s32 deviceHandler_DVD_setupFile(file_handle* file, file_handle* file2, int numTo
 }
 
 s32 deviceHandler_DVD_init(file_handle* file){
-  file->status = initialize_disc(ENABLE_BYDISK);
-  if(file->status == DRV_ERROR){
-	  uiDrawObj_t *msgBox = DrawMessageBox(D_FAIL,"Failed to mount DVD. Press A");
-	  DrawPublish(msgBox);
-	  wait_press_A();
-	  DrawDispose(msgBox);
-	  return file->status;
-  }
-  dvd_init=1;
-  return file->status;
+	if(!swissSettings.hasDVDDrive) return ENODEV;
+	
+	file->status = initialize_disc(ENABLE_BYDISK);
+	dvd_init = file->status != DRV_ERROR;
+	return !dvd_init;
 }
 
 s32 deviceHandler_DVD_deinit(file_handle* file) {
@@ -576,6 +560,16 @@ u32 deviceHandler_DVD_emulated() {
 		return EMU_READ;
 }
 
+char* deviceHandler_DVD_status(file_handle* file) {
+	if(!swissSettings.hasDVDDrive) {
+		return NULL;
+	}
+	if(file->status == DRV_ERROR) {
+		return dvd_error_str();
+	}
+	return NULL;
+}
+
 DEVICEHANDLER_INTERFACE __device_dvd = {
 	DEVICE_ID_0,
 	"Disc Drive",
@@ -600,4 +594,5 @@ DEVICEHANDLER_INTERFACE __device_dvd = {
 	(_fn_setupFile)&deviceHandler_DVD_setupFile,
 	(_fn_deinit)&deviceHandler_DVD_deinit,
 	(_fn_emulated)&deviceHandler_DVD_emulated,
+	(_fn_status)&deviceHandler_DVD_status,
 };

--- a/cube/swiss/source/devices/fat/deviceHandler-FAT.c
+++ b/cube/swiss/source/devices/fat/deviceHandler-FAT.c
@@ -93,20 +93,20 @@ file_handle initial_ATA_C =
 	};
 
 static device_info initial_FAT_info[FF_VOLUMES];
-
+	
 device_info* deviceHandler_FAT_info(file_handle* file) {
 	device_info* info = NULL;
-	DWORD freeClusters;
-	FATFS* fatfs;
+		DWORD freeClusters;
+		FATFS *fatfs;
 	if(f_getfree(file->name, &freeClusters, &fatfs) == FR_OK) {
 		info = &initial_FAT_info[fatfs->pdrv];
-		info->freeSpace = (u64)(freeClusters) * fatfs->csize * fatfs->ssize;
-		info->totalSpace = (u64)(fatfs->n_fatent - 2) * fatfs->csize * fatfs->ssize;
+			info->freeSpace = (u64)(freeClusters) * fatfs->csize * fatfs->ssize;
+			info->totalSpace = (u64)(fatfs->n_fatent - 2) * fatfs->csize * fatfs->ssize;
 		info->metric = true;
-	}
+		}
 	return info;
-}
-
+		}
+	
 s32 deviceHandler_FAT_readDir(file_handle* ffile, file_handle** dir, u32 type) {	
 
 	DIRF* dp = malloc(sizeof(DIRF));
@@ -343,7 +343,7 @@ s32 fatFs_Mount(u8 devNum, char *path) {
 		disk_shutdown(devNum);
 	}
 	fs[devNum] = (FATFS*)malloc(sizeof(FATFS));
-	return f_mount(fs[devNum], path, 1) == FR_OK;
+	return f_mount(fs[devNum], path, 1);
 }
 
 void setSDGeckoSpeed(int slot, bool fast) {
@@ -354,54 +354,54 @@ void setSDGeckoSpeed(int slot, bool fast) {
 s32 deviceHandler_FAT_init(file_handle* file) {
 	int isSDCard = IS_SDCARD(file->name);
 	int slot = GET_SLOT(file->name);
-	int ret = 0;
+	file->status = 0;
 	print_gecko("Init %s %i\r\n", (isSDCard ? "SD":"ATA"), slot);
 	// SD Card - Slot A
 	if(isSDCard && slot == 0) {
 		setSDGeckoSpeed(slot, swissSettings.exiSpeed);
 		__device_sd_a.features |= FEAT_BOOT_GCM;
-		ret = fatFs_Mount(DEV_SDA, "sda:/");
-		if(!ret) {
+		file->status = fatFs_Mount(DEV_SDA, "sda:/");
+		if(file->status != FR_OK) {
 			setSDGeckoSpeed(slot, false);
 			__device_sd_a.features &= ~FEAT_BOOT_GCM;
-			ret = fatFs_Mount(DEV_SDA, "sda:/");
+			file->status = fatFs_Mount(DEV_SDA, "sda:/");
 		}
 	}
 	// SD Card - Slot B
 	if(isSDCard && slot == 1) {
 		setSDGeckoSpeed(slot, swissSettings.exiSpeed);
 		__device_sd_b.features |= FEAT_BOOT_GCM;
-		ret = fatFs_Mount(DEV_SDB, "sdb:/");
-		if(!ret) {
+		file->status = fatFs_Mount(DEV_SDB, "sdb:/");
+		if(file->status != FR_OK) {
 			setSDGeckoSpeed(slot, false);
 			__device_sd_b.features &= ~FEAT_BOOT_GCM;
-			ret = fatFs_Mount(DEV_SDB, "sdb:/");
+			file->status = fatFs_Mount(DEV_SDB, "sdb:/");
 		}
 	}
 	// SD Card - SD2SP2
 	if(isSDCard && slot == 2) {
 		setSDGeckoSpeed(slot, swissSettings.exiSpeed);
 		__device_sd_c.features |= FEAT_BOOT_GCM;
-		ret = fatFs_Mount(DEV_SDC, "sdc:/");
-		if(!ret) {
+		file->status = fatFs_Mount(DEV_SDC, "sdc:/");
+		if(file->status != FR_OK) {
 			setSDGeckoSpeed(slot, false);
 			__device_sd_c.features &= ~FEAT_BOOT_GCM;
-			ret = fatFs_Mount(DEV_SDC, "sdc:/");
+			file->status = fatFs_Mount(DEV_SDC, "sdc:/");
 		}
 	}
 	// IDE-EXI - Slot A
 	if(!isSDCard && slot == 0) {
-		ret = fatFs_Mount(DEV_ATAA, "ataa:/");
+		file->status = fatFs_Mount(DEV_ATAA, "ataa:/");
 	}
 	// IDE-EXI - Slot B
 	if(!isSDCard && slot == 1) {
-		ret = fatFs_Mount(DEV_ATAB, "atab:/");
+		file->status = fatFs_Mount(DEV_ATAB, "atab:/");
 	}
 	// M.2 Loader
 	if(!isSDCard && slot == 2) {
-		ret = fatFs_Mount(DEV_ATAC, "atac:/");
+		file->status = fatFs_Mount(DEV_ATAC, "atac:/");
 	}
-	return ret;
+	return file->status == FR_OK ? 0 : EIO;
 }
 
 s32 deviceHandler_FAT_closeFile(file_handle* file) {
@@ -482,6 +482,53 @@ u32 deviceHandler_FAT_emulated_ata() {
 		return EMU_READ | EMU_BUS_ARBITER;
 }
 
+char* deviceHandler_FAT_status(file_handle* file) {
+	switch(file->status) {
+		case FR_OK:			/* (0) Succeeded */
+			return NULL;
+		case FR_DISK_ERR:
+			return "Error occurred in the low level disk I/O layer";
+		case FR_INT_ERR:
+			return "Assertion failed";
+		case FR_NOT_READY:
+			return "The physical drive cannot work";
+		case FR_NO_FILE:
+			return "Could not find the file";
+		case FR_NO_PATH:
+			return "Could not find the path";
+		case FR_INVALID_NAME:
+			return "The path name format is invalid";
+		case FR_DENIED:
+			return "Access denied due to prohibited access or directory full";
+		case FR_EXIST:
+			return "Access denied due to prohibited access";
+		case FR_INVALID_OBJECT:
+			return "The file/directory object is invalid";
+		case FR_WRITE_PROTECTED:
+			return "The physical drive is write protected";
+		case FR_INVALID_DRIVE:
+			return "The logical drive number is invalid";
+		case FR_NOT_ENABLED:
+			return "The volume has no work area";
+		case FR_NO_FILESYSTEM:
+			return "There is no valid FAT volume";
+		case FR_MKFS_ABORTED:
+			return "The f_mkfs() aborted due to any problem";
+		case FR_TIMEOUT:
+			return "Could not get a grant to access the volume within defined period";
+		case FR_LOCKED:
+			return "The operation is rejected according to the file sharing policy";
+		case FR_NOT_ENOUGH_CORE:
+			return "LFN working buffer could not be allocated";
+		case FR_TOO_MANY_OPEN_FILES:
+			return "Number of open files > FF_FS_LOCK";
+		case FR_INVALID_PARAMETER:
+			return "Given parameter is invalid";
+		default:
+			return "Unknown error occurred";
+	}
+}
+
 DEVICEHANDLER_INTERFACE __device_sd_a = {
 	DEVICE_ID_1,
 	"SD Card Adapter",
@@ -506,6 +553,7 @@ DEVICEHANDLER_INTERFACE __device_sd_a = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_sd,
+	(_fn_status)&deviceHandler_FAT_status,
 };
 
 DEVICEHANDLER_INTERFACE __device_sd_b = {
@@ -532,6 +580,7 @@ DEVICEHANDLER_INTERFACE __device_sd_b = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_sd,
+	(_fn_status)&deviceHandler_FAT_status,
 };
 
 DEVICEHANDLER_INTERFACE __device_ata_a = {
@@ -558,6 +607,7 @@ DEVICEHANDLER_INTERFACE __device_ata_a = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_ata,
+	(_fn_status)&deviceHandler_FAT_status,
 };
 
 DEVICEHANDLER_INTERFACE __device_ata_b = {
@@ -584,6 +634,7 @@ DEVICEHANDLER_INTERFACE __device_ata_b = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_ata,
+	(_fn_status)&deviceHandler_FAT_status,
 };
 
 DEVICEHANDLER_INTERFACE __device_sd_c = {
@@ -610,6 +661,7 @@ DEVICEHANDLER_INTERFACE __device_sd_c = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_sd,
+	(_fn_status)&deviceHandler_FAT_status,
 };
 
 DEVICEHANDLER_INTERFACE __device_ata_c = {
@@ -636,4 +688,5 @@ DEVICEHANDLER_INTERFACE __device_ata_c = {
 	(_fn_setupFile)&deviceHandler_FAT_setupFile,
 	(_fn_deinit)&deviceHandler_FAT_deinit,
 	(_fn_emulated)&deviceHandler_FAT_emulated_sd,
+	(_fn_status)&deviceHandler_FAT_status,
 };

--- a/cube/swiss/source/devices/fat/deviceHandler-FAT.h
+++ b/cube/swiss/source/devices/fat/deviceHandler-FAT.h
@@ -25,6 +25,7 @@ extern s32 deviceHandler_FAT_writeFile(file_handle* file, void* buffer, u32 leng
 extern s32 deviceHandler_FAT_closeFile(file_handle* file);
 extern s32 deviceHandler_FAT_deleteFile(file_handle* file);
 extern s32 deviceHandler_FAT_renameFile(file_handle* file, char* name);
+extern char* deviceHandler_FAT_status(file_handle* file);
 
 #endif
 

--- a/cube/swiss/source/devices/gcloader/deviceHandler-gcloader.c
+++ b/cube/swiss/source/devices/gcloader/deviceHandler-gcloader.c
@@ -262,7 +262,7 @@ fail:
 	return 0;
 }
 
-s32 deviceHandler_GCLOADER_init(file_handle* file) {
+s32 deviceHandler_GCLOADER_init(file_handle* file){
 	if(gcloaderfs != NULL) {
 		f_unmount("gcldr:/");
 		free(gcloaderfs);
@@ -270,8 +270,8 @@ s32 deviceHandler_GCLOADER_init(file_handle* file) {
 		disk_shutdown(DEV_GCLDR);
 	}
 	gcloaderfs = (FATFS*)malloc(sizeof(FATFS));
-	return f_mount(gcloaderfs, "gcldr:/", 1) == FR_OK;
-}
+	return f_mount(gcloaderfs, "gcldr:/", 1) == FR_OK ? 0 : EIO;
+		}
 
 s32 deviceHandler_GCLOADER_deinit(file_handle* file) {
 	deviceHandler_FAT_closeFile(file);
@@ -345,4 +345,5 @@ DEVICEHANDLER_INTERFACE __device_gcloader = {
 	(_fn_setupFile)&deviceHandler_GCLOADER_setupFile,
 	(_fn_deinit)&deviceHandler_GCLOADER_deinit,
 	(_fn_emulated)&deviceHandler_GCLOADER_emulated,
+	(_fn_status)&deviceHandler_FAT_status,
 };

--- a/cube/swiss/source/devices/qoob/deviceHandler-Qoob.c
+++ b/cube/swiss/source/devices/qoob/deviceHandler-Qoob.c
@@ -95,20 +95,6 @@ s32 deviceHandler_Qoob_readFile(file_handle* file, void* buffer, u32 length) {
 	return length;
 }
 
-s32 deviceHandler_Qoob_init(file_handle* file) {
-	ipl_set_config(0);
-	return 1;
-}
-
-s32 deviceHandler_Qoob_deinit(file_handle* file) {
-	ipl_set_config(6);
-	return 0;
-}
-
-s32 deviceHandler_Qoob_closeFile(file_handle* file) {
-    return 0;
-}
-
 bool deviceHandler_Qoob_test() {
 	// Read 1024 bytes from certain sections of the IPL Mask ROM and compare with Qoob enabled/disabled
 	char *qoobData = (char*)memalign(32, 0x400);
@@ -137,6 +123,27 @@ bool deviceHandler_Qoob_test() {
 	return qoobFound;
 }
 
+s32 deviceHandler_Qoob_init(file_handle* file) {
+	if(!deviceHandler_Qoob_test()) {
+		return ENODEV;
+	}
+	ipl_set_config(0);
+	return 0;
+}
+
+s32 deviceHandler_Qoob_deinit(file_handle* file) {
+	ipl_set_config(6);
+	return 0;
+}
+
+s32 deviceHandler_Qoob_closeFile(file_handle* file) {
+    return 0;
+}
+
+char* deviceHandler_Qoob_status(file_handle* file) {
+	return NULL;
+}
+
 DEVICEHANDLER_INTERFACE __device_qoob = {
 	DEVICE_ID_7,
 	"Qoob Modchip",
@@ -161,4 +168,5 @@ DEVICEHANDLER_INTERFACE __device_qoob = {
 	(_fn_setupFile)NULL,
 	(_fn_deinit)&deviceHandler_Qoob_deinit,
 	(_fn_emulated)NULL,
+	(_fn_status)&deviceHandler_Qoob_status,
 };

--- a/cube/swiss/source/devices/smb/deviceHandler-SMB.h
+++ b/cube/swiss/source/devices/smb/deviceHandler-SMB.h
@@ -26,11 +26,6 @@
 
 #include "deviceHandler.h"
 
-// error codes
-#define SMB_NETINITERR -110
-#define SMB_SMBCFGERR  -111
-#define SMB_SMBERR -112
-
 extern DEVICEHANDLER_INTERFACE __device_smb;
 
 

--- a/cube/swiss/source/devices/system/deviceHandler-SYS.c
+++ b/cube/swiss/source/devices/system/deviceHandler-SYS.c
@@ -314,7 +314,7 @@ s32 deviceHandler_SYS_init(file_handle* file) {
 		initial_SYS_info.totalSpace += rom_sizes[i];
 	}
 
-	return 1;
+	return 0;
 }
 
 s32 deviceHandler_SYS_readDir(file_handle* ffile, file_handle** dir, u32 type) {
@@ -363,6 +363,10 @@ bool deviceHandler_SYS_test() {
 	return true;
 }
 
+char* deviceHandler_SYS_status(file_handle* file) {
+	return NULL;
+}
+
 DEVICEHANDLER_INTERFACE __device_sys = {
 	DEVICE_ID_9,
 	"Various",
@@ -387,4 +391,5 @@ DEVICEHANDLER_INTERFACE __device_sys = {
 	(_fn_setupFile)NULL,
 	(_fn_deinit)&deviceHandler_SYS_deinit,
 	(_fn_emulated)NULL,
+	(_fn_status)&deviceHandler_SYS_status,
 };

--- a/cube/swiss/source/devices/usbgecko/deviceHandler-usbgecko.c
+++ b/cube/swiss/source/devices/usbgecko/deviceHandler-usbgecko.c
@@ -15,6 +15,8 @@
 #include "usbgecko.h"
 #include "patcher.h"
 
+#define NO_PC (-1)
+
 file_handle initial_USBGecko =
 	{ "./",     // directory
 	  0ULL,     // fileBase (u64)
@@ -190,12 +192,10 @@ s32 deviceHandler_USBGecko_setupFile(file_handle* file, file_handle* file2, int 
 }
 
 s32 deviceHandler_USBGecko_init(file_handle* file) {
-	s32 success = 0;
-	uiDrawObj_t *msgBox = DrawPublish(DrawProgressBar(true, 0, "Looking for USBGecko in Slot B"));
+	s32 res = 0;
+	uiDrawObj_t *msgBox = DrawPublish(DrawProgressBar(true, 0, "Waiting for PC ..."));
 	if(usb_isgeckoalive(1)) {
 		s32 retries = 1000;
-		DrawDispose(msgBox);
-		msgBox = DrawPublish(DrawProgressBar(true, 0, "Waiting for PC ..."));
 		
 		usb_flush(1);
 		usbgecko_lock_file(0);
@@ -204,15 +204,15 @@ s32 deviceHandler_USBGecko_init(file_handle* file) {
 			VIDEO_WaitVSync();
 			retries--;
 		}
-		success = retries > 1 ? 1 : 0;
-		if(!success) {
-			DrawDispose(msgBox);
-			msgBox = DrawPublish(DrawMessageBox(D_INFO,"Couldn't find PC!"));
-			sleep(5);
+		if(!retries) {
+			file->status = NO_PC;
 		}
 	}
+	else {
+		res = ENODEV;
+	}
 	DrawDispose(msgBox);
-	return success;
+	return res;
 }
 
 s32 deviceHandler_USBGecko_deinit(file_handle* file) {
@@ -230,6 +230,12 @@ bool deviceHandler_USBGecko_test() {
 
 u32 deviceHandler_USBGecko_emulated() {
 	return EMU_READ | EMU_BUS_ARBITER;
+}
+
+char* deviceHandler_USBGecko_status(file_handle* file) {
+	if(file->status == NO_PC)
+		return "Couldn't connect to PC";
+	return NULL;
 }
 
 DEVICEHANDLER_INTERFACE __device_usbgecko = {
@@ -256,4 +262,5 @@ DEVICEHANDLER_INTERFACE __device_usbgecko = {
 	(_fn_setupFile)&deviceHandler_USBGecko_setupFile,
 	(_fn_deinit)&deviceHandler_USBGecko_deinit,
 	(_fn_emulated)&deviceHandler_USBGecko_emulated,
+	(_fn_status)&deviceHandler_USBGecko_status,
 };

--- a/cube/swiss/source/devices/wiikeyfusion/deviceHandler-wiikeyfusion.c
+++ b/cube/swiss/source/devices/wiikeyfusion/deviceHandler-wiikeyfusion.c
@@ -19,7 +19,6 @@
 #include "patcher.h"
 #include "dvd.h"
 
-const DISC_INTERFACE* wkf = &__io_wkf;
 FATFS *wkffs = NULL;
 
 file_handle initial_WKF =
@@ -186,8 +185,13 @@ s32 deviceHandler_WKF_setupFile(file_handle* file, file_handle* file2, int numTo
 	return 1;
 }
 
-s32 deviceHandler_WKF_init(file_handle* file) {
-	wkfReinit();
+bool deviceHandler_WKF_test() {
+	return swissSettings.hasDVDDrive && (__wkfSpiReadId() != 0 && __wkfSpiReadId() != 0xFFFFFFFF);
+}
+
+s32 deviceHandler_WKF_init(file_handle* file){
+	if(!deviceHandler_WKF_test()) return ENODEV;
+	wkfReinit();	// TODO extended error status
 	if(wkffs != NULL) {
 		f_unmount("wkf:/");
 		free(wkffs);
@@ -195,8 +199,8 @@ s32 deviceHandler_WKF_init(file_handle* file) {
 		disk_shutdown(DEV_WKF);
 	}
 	wkffs = (FATFS*)malloc(sizeof(FATFS));
-	return f_mount(wkffs, "wkf:/", 1) == FR_OK;
-}
+	return f_mount(wkffs, "wkf:/", 1) == FR_OK ? 0 : EIO;
+		}
 
 s32 deviceHandler_WKF_deinit(file_handle* file) {
 	deviceHandler_FAT_closeFile(file);
@@ -207,10 +211,6 @@ s32 deviceHandler_WKF_deinit(file_handle* file) {
 		disk_shutdown(DEV_WKF);
 	}
 	return 0;
-}
-
-bool deviceHandler_WKF_test() {
-	return swissSettings.hasDVDDrive && (__wkfSpiReadId() != 0 && __wkfSpiReadId() != 0xFFFFFFFF);
 }
 
 u32 deviceHandler_WKF_emulated() {
@@ -253,4 +253,5 @@ DEVICEHANDLER_INTERFACE __device_wkf = {
 	(_fn_setupFile)&deviceHandler_WKF_setupFile,
 	(_fn_deinit)&deviceHandler_WKF_deinit,
 	(_fn_emulated)&deviceHandler_WKF_emulated,
+	(_fn_status)&deviceHandler_FAT_status,
 };

--- a/cube/swiss/source/devices/wode/deviceHandler-WODE.c
+++ b/cube/swiss/source/devices/wode/deviceHandler-WODE.c
@@ -21,7 +21,7 @@
 char wode_regions[]  = {'J','E','P','A','K'};
 char *wode_regions_str[] = {"JPN","USA","EUR","ALL","KOR"};
 char disktype[] = {'?', 'G','W','W','I' };
-int wodeInited = 0;
+s32 wodeInited = 0;
 
 file_handle initial_WODE =
 	{ "wode:/",     // directory
@@ -37,15 +37,15 @@ device_info initial_WODE_info = {
 	true
 };
 	
-int startupWode() {
+s32 startupWode() {
 	if(OpenWode() == 0) {
 		CloseWode();
 		if(OpenWode() == 0) {
-			uiDrawObj_t *msgBox = DrawMessageBox(D_FAIL,"No Wode found! Press A");
+			uiDrawObj_t *msgBox = DrawMessageBox(D_FAIL,"No WODE found! Press A");
 			DrawPublish(msgBox);
 			wait_press_A();
 			DrawDispose(msgBox);
-			return -1;
+			return ENODEV;
 		}
 	}
 	// Wode initialised, return success
@@ -56,7 +56,7 @@ int startupWode() {
 			wode_version_info->fpga_version, wode_version_info->hw_version);
 		return 0;
 	}
-	return -1;
+	return EIO;
 }
 
 device_info* deviceHandler_WODE_info(file_handle* file) {
@@ -248,9 +248,10 @@ s32 deviceHandler_WODE_setupFile(file_handle* file, file_handle* file2, int numT
 	return 1;
 }
 
-s32 deviceHandler_WODE_init(file_handle* file){
-	wodeInited = startupWode() == 0 ? 1:0;
-	return wodeInited;
+s32 deviceHandler_WODE_init(file_handle* file) {
+	int res = startupWode();
+	wodeInited = !res ? 1:0;
+	return res;
 }
 
 s32 deviceHandler_WODE_deinit(file_handle* file) {
@@ -284,6 +285,10 @@ u32 deviceHandler_WODE_emulated() {
 		return EMU_READ;
 }
 
+char* deviceHandler_WODE_status(file_handle* file) {
+	return NULL;
+}
+
 DEVICEHANDLER_INTERFACE __device_wode = {
 	DEVICE_ID_C,
 	"WODE",
@@ -308,4 +313,5 @@ DEVICEHANDLER_INTERFACE __device_wode = {
 	(_fn_setupFile)&deviceHandler_WODE_setupFile,
 	(_fn_deinit)&deviceHandler_WODE_deinit,
 	(_fn_emulated)&deviceHandler_WODE_emulated,
+	(_fn_status)&deviceHandler_WODE_status,
 };

--- a/cube/swiss/source/gcm.c
+++ b/cube/swiss/source/gcm.c
@@ -451,13 +451,13 @@ int patch_gcm(file_handle *file, ExecutableFile *filesToPatch, int numToPatch) {
 		if(devices[DEVICE_CONFIG] == &__device_sd_a || devices[DEVICE_CONFIG] == &__device_sd_b || devices[DEVICE_CONFIG] == &__device_sd_c) {
 			devices[DEVICE_PATCHES] = devices[DEVICE_CONFIG];
 		}
-		else if(deviceHandler_test(&__device_sd_c)) {
+		else if(deviceHandler_getDeviceAvailable(&__device_sd_c)) {
 			devices[DEVICE_PATCHES] = &__device_sd_c;
 		}
-		else if(deviceHandler_test(&__device_sd_b)) {
+		else if(deviceHandler_getDeviceAvailable(&__device_sd_b)) {
 			devices[DEVICE_PATCHES] = &__device_sd_b;
 		}
-		else if(deviceHandler_test(&__device_sd_a)) {
+		else if(deviceHandler_getDeviceAvailable(&__device_sd_a)) {
 			devices[DEVICE_PATCHES] = &__device_sd_a;
 		}
 		else {
@@ -582,7 +582,7 @@ int patch_gcm(file_handle *file, ExecutableFile *filesToPatch, int numToPatch) {
 		if(patched) {
 			if(!patchDeviceReady) {
 				deviceHandler_setStatEnabled(0);
-				if(!devices[DEVICE_PATCHES]->init(devices[DEVICE_PATCHES]->initial)) {
+				if(devices[DEVICE_PATCHES]->init(devices[DEVICE_PATCHES]->initial)) {
 					deviceHandler_setStatEnabled(1);
 					DrawDispose(progBox);
 					return false;

--- a/cube/swiss/source/main.c
+++ b/cube/swiss/source/main.c
@@ -214,7 +214,7 @@ int main ()
 	}
 	if(devices[DEVICE_CUR] != NULL) {
 		print_gecko("Detected %s\r\n", devices[DEVICE_CUR]->deviceName);
-		if(devices[DEVICE_CUR]->init(devices[DEVICE_CUR]->initial)) {
+		if(!devices[DEVICE_CUR]->init(devices[DEVICE_CUR]->initial)) {
 			if(devices[DEVICE_CUR]->features & FEAT_AUTOLOAD_DOL) {
 				load_auto_dol();
 			}

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2275,18 +2275,6 @@ void select_device(int type)
 	devices[type] = allDevices[curDevice];
 }
 
-char* getErrMsg(s32 err) {
-	switch(err) {
-		case ENODEV:
-			return "No device found";
-		case EIO:
-			return "I/O error";
-		case EFAULT:
-			return "General Error";
-	}
-	return "Unknown error";
-}
-
 void menu_loop()
 { 
 	while(PAD_ButtonsHeld(0) & PAD_BUTTON_A) { VIDEO_WaitVSync (); }
@@ -2313,7 +2301,7 @@ void menu_loop()
 				}
 				DrawDispose(msgBox);
 				char* statusMsg = devices[DEVICE_CUR]->status(devices[DEVICE_CUR]->initial);
-				msgBox = DrawPublish(DrawMessageBox(D_FAIL, statusMsg ? statusMsg : getErrMsg(ret)));
+				msgBox = DrawPublish(DrawMessageBox(D_FAIL, statusMsg ? statusMsg : strerror(ret)));
 				sleep(2);
 				DrawDispose(msgBox);
 				return;

--- a/cube/swiss/source/util.c
+++ b/cube/swiss/source/util.c
@@ -191,7 +191,7 @@ int load_existing_entry(char *entry) {
 		print_gecko("Device required for entry [%s]\r\n", entryDevice->deviceName);
 		
 		// Init the device if it isn't one we were about to browse anyway
-		if(devices[DEVICE_CUR] == entryDevice || entryDevice->init(entryDevice->initial)) {
+		if(devices[DEVICE_CUR] == entryDevice || !entryDevice->init(entryDevice->initial)) {
 			if(devices[DEVICE_CUR] && devices[DEVICE_CUR] != entryDevice) {
 				devices[DEVICE_CUR]->deinit(devices[DEVICE_CUR]->initial);
 			}


### PR DESCRIPTION
I'm using errno where I can but have implemented an extension should devices need to convey something extra about their errors via deviceHandler->status(). I've also tidied up some device handling so this needs a thorough test.

Devices tested so far:
- [x] SD Cards (Slot A / B / SP2)
- [x] Memory Cards (Slot A / B)
- [x] DVD
- [ ] IDE-EXI (Slot A / B)
- [x] Qoob Pro
- [ ] SMB
- [x] System
- [x] USB Gecko
- [ ] FTP
- [ ] FSP
- [x] Wiikey / WASP
- [x] WODE
- [x] GC Loader
- [ ] M.2 Loader