### PR TITLE
Autoboot command line argument

### DIFF
--- a/cube/swiss/include/swiss.h
+++ b/cube/swiss/include/swiss.h
@@ -130,6 +130,7 @@ typedef struct {
 	int showHiddenFiles;
 	int recentListLevel;	// on, lazy, off
 	char gcloaderTopVersion[32];
+	bool autoboot;
 	char autoload[PATHNAME_MAX];
 	char recent[RECENT_MAX][PATHNAME_MAX];
 } SwissSettings;

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -544,6 +544,9 @@ void config_parse_legacy(char *configData, void (*progress_indicator)(char*, int
 				else if(!strcmp("Autoload", name)) {
 					strlcpy(swissSettings.autoload, value, sizeof(swissSettings.autoload));
 				}
+				else if(!strcmp("Autoboot", name)) {
+					swissSettings.autoboot = !strcmp("Yes", value) ? 1:0;
+				}
 				else if(!strncmp("Recent_", name, strlen("Recent_"))) {
 					int recent_slot = atoi(name+strlen("Recent_"));
 					if(recent_slot >= 0 && recent_slot < RECENT_MAX) {
@@ -786,6 +789,16 @@ void config_parse_global(char *configData) {
 				}
 				else if(!strcmp("Autoload", name)) {
 					strlcpy(swissSettings.autoload, value, sizeof(swissSettings.autoload));
+				}
+				else if(!strcmp("Autoboot", name)) {
+					swissSettings.autoboot = !strcmp("Yes", value) ? 1:0;
+				}
+				else if(!strncmp("Recent_", name, strlen("Recent_"))) {
+					int recent_slot = atoi(name+strlen("Recent_"));
+					if(recent_slot >= 0 && recent_slot < RECENT_MAX) {
+						//print_gecko("found recent num %i [%s]\r\n", recent_slot, value);
+						strncpy(swissSettings.recent[recent_slot], value, PATHNAME_MAX);
+					}
 				}
 			}
 		}

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -175,7 +175,7 @@ int config_update_global(bool checkConfigDevice) {
 	fprintf(fp, "RecentListLevel=%s\r\n", recentListLevelStr[swissSettings.recentListLevel]);
 	fprintf(fp, "GCLoaderTopVersion=%s\r\n", swissSettings.gcloaderTopVersion);
 	fprintf(fp, "Autoload=%s\r\n", swissSettings.autoload);
-	fprintf(fp, "Autoboot=%d\r\n", swissSettings.autoboot);
+	fprintf(fp, "Autoboot=%s\r\n", swissSettings.autoboot ? "Yes":"No");
 
 	// Write out the default game config portion too
 	fprintf(fp, "Force Video Mode=%s\r\n", gameVModeStr[swissSettings.gameVMode]);

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -175,6 +175,7 @@ int config_update_global(bool checkConfigDevice) {
 	fprintf(fp, "RecentListLevel=%s\r\n", recentListLevelStr[swissSettings.recentListLevel]);
 	fprintf(fp, "GCLoaderTopVersion=%s\r\n", swissSettings.gcloaderTopVersion);
 	fprintf(fp, "Autoload=%s\r\n", swissSettings.autoload);
+	fprintf(fp, "Autoboot=%d\r\n", swissSettings.autoboot);
 
 	// Write out the default game config portion too
 	fprintf(fp, "Force Video Mode=%s\r\n", gameVModeStr[swissSettings.gameVMode]);

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -1715,8 +1715,11 @@ void load_game() {
 	}
 	
 	DrawDispose(msgBox);
-	// Show game info or return to the menu
-	int bootMode = info_game();
+	int bootMode = 1;
+	if (!swissSettings.autoboot) {
+		// Show game info or return to the menu
+		bootMode = info_game();
+	}
 	if(!bootMode) return;
 	
 	if(tgcFile.magic == TGC_MAGIC) {

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2047,15 +2047,17 @@ int info_game()
 	uiDrawObj_t *infoPanel = DrawPublish(draw_game_info());
 	int num_cheats = -1;
 
-	// Skip inputs if autoboot is set
-	if (swissSettings.autoboot && !(PAD_ButtonsHeld(0) & PAD_TRIGGER_L)) {
-		return 1;
-	}
-
 	while(1) {
-		while(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R)){ VIDEO_WaitVSync (); }
-		while(!(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R))){ VIDEO_WaitVSync (); }
-		u32 buttons = PAD_ButtonsHeld(0);
+		u32 buttons = 0;
+		if (swissSettings.autoboot && !(PAD_ButtonsHeld(0) & PAD_TRIGGER_L)) {
+			// Skip inputs if autoboot is set
+			buttons = PAD_BUTTON_A;
+		} else {
+			while(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R)){ VIDEO_WaitVSync (); }
+			while(!(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R))){ VIDEO_WaitVSync (); }
+			buttons = PAD_ButtonsHeld(0);
+		}
+
 		if(buttons & (PAD_BUTTON_B|PAD_BUTTON_A)){
 			ret = (buttons & PAD_BUTTON_A) ? (buttons & PAD_TRIGGER_L) ? 2:1:0;
 			// WODE can't return from here.

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2046,8 +2046,13 @@ int info_game()
 	config_find(config);	// populate
 	uiDrawObj_t *infoPanel = DrawPublish(draw_game_info());
 	int num_cheats = -1;
+
 	// Skip inputs if autoboot is set
-	while(!swissSettings.autoboot) {
+	if (swissSettings.autoboot && !(PAD_ButtonsHeld(0) & PAD_TRIGGER_L)) {
+		return 1;
+	}
+
+	while(1) {
 		while(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R)){ VIDEO_WaitVSync (); }
 		while(!(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R))){ VIDEO_WaitVSync (); }
 		u32 buttons = PAD_ButtonsHeld(0);
@@ -2100,7 +2105,6 @@ int info_game()
 		}
 		while(PAD_ButtonsHeld(0) & PAD_BUTTON_A){ VIDEO_WaitVSync (); }
 	}
-	if (swissSettings.autoboot) ret = 1;
 	while(PAD_ButtonsHeld(0) & PAD_BUTTON_A){ VIDEO_WaitVSync (); }
 	DrawDispose(infoPanel);
 	// Load config for this game into our current settings

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -1715,11 +1715,8 @@ void load_game() {
 	}
 	
 	DrawDispose(msgBox);
-	int bootMode = 1;
-	if (!swissSettings.autoboot) {
-		// Show game info or return to the menu
-		bootMode = info_game();
-	}
+	// Show game info or return to the menu
+	int bootMode = info_game();
 	if(!bootMode) return;
 	
 	if(tgcFile.magic == TGC_MAGIC) {
@@ -2049,7 +2046,8 @@ int info_game()
 	config_find(config);	// populate
 	uiDrawObj_t *infoPanel = DrawPublish(draw_game_info());
 	int num_cheats = -1;
-	while(1) {
+	// Skip inputs if autoboot is set
+	while(!swissSettings.autoboot) {
 		while(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R)){ VIDEO_WaitVSync (); }
 		while(!(PAD_ButtonsHeld(0) & (PAD_BUTTON_X | PAD_BUTTON_B | PAD_BUTTON_A | PAD_BUTTON_Y | PAD_TRIGGER_Z | PAD_TRIGGER_R))){ VIDEO_WaitVSync (); }
 		u32 buttons = PAD_ButtonsHeld(0);
@@ -2102,6 +2100,7 @@ int info_game()
 		}
 		while(PAD_ButtonsHeld(0) & PAD_BUTTON_A){ VIDEO_WaitVSync (); }
 	}
+	if (swissSettings.autoboot) ret = 1;
 	while(PAD_ButtonsHeld(0) & PAD_BUTTON_A){ VIDEO_WaitVSync (); }
 	DrawDispose(infoPanel);
 	// Load config for this game into our current settings


### PR DESCRIPTION
Create an Autoboot setting which can be passed as a command line argument

~Note: this does not include adding `Autoboot` to `config_update_global` which avoids a situation where you can not open Swiss normally after using Autoboot.~

Note: Autoboot can be skipped by holding L