### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -15,12 +15,12 @@ jobs:
         sudo apt-get install -y --no-install-recommends gcc gcc-mingw-w64-i686 libc6-dev libc6-i386 p7zip-full xorriso
 
     - name: Checkout swiss-gc
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Checkout libogc2
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: extremscorner/libogc2
         path: cube/libogc2
@@ -33,7 +33,7 @@ jobs:
       run: make
 
     - name: Upload Swiss artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: swiss-gc
         path: swiss_r*/*


### PR DESCRIPTION
This PR just updates the GitHub actions in the workflow to their respective newest versions.
See: https://github.com/emukidid/swiss-gc/actions/runs/3269203056
Node.js 12 actions have been deprecated and the respective actions already have Node.js 16 versions available which are being used in this PR.