### PR TITLE
Mark the USBGecko Makefile as not being parallelizable, so that it doesn't cause the entire build to fail if you run make in parallel

### DIFF
--- a/pc/usbgecko/Makefile
+++ b/pc/usbgecko/Makefile
@@ -34,3 +34,5 @@ windows:
 	$(WIN-CC) $(WIN-LFLAGS) $(OBJS) -o $(TARGET).exe $(WIN-LFLAGS)
 	$(STRIP) -g $(TARGET).exe
 	@rm -f *.o
+
+.NOTPARALLEL:


### PR DESCRIPTION
With this change, I am able to `make -j32` the entire project successfully (which greatly speeds up the build process).

The reason the Makefile isn't parallelizable is that both the `linux` and `windows` targets write their `.o` files to the same directory, causing the linker to try to link ELF64 and PE32 binaries together, which it can't do. The Makefile would need to be restructured so that build output goes to two different places for this Makefile to be parallelizable, but that feels like an unnecessary amount of work given how little improvement parallelizing this Makefile would provide (compared to being able to compile the whole thing with `-j` now).