### PR TITLE
Draft: Add the ability to disable the device selector

### DIFF
--- a/cube/swiss/include/swiss.h
+++ b/cube/swiss/include/swiss.h
@@ -148,8 +148,16 @@ typedef struct {
 	char autoload[PATHNAME_MAX];
 	char flattenDir[PATHNAME_MAX];
 	char recent[RECENT_MAX][PATHNAME_MAX];
+	u8 deviceSelectorType; // on, show only, off
 } SwissSettings;
 extern SwissSettings swissSettings;
+
+enum deviceSelectorTypes
+{
+	DEVICE_SELECTOR_ENABLED=0,
+	DEVICE_SELECTOR_SHOW_ONLY,
+	DEVICE_SELECTOR_DISABLED
+};
 
 enum fileOptions
 {

--- a/cube/swiss/include/swiss.h
+++ b/cube/swiss/include/swiss.h
@@ -33,7 +33,6 @@ extern int needsDeviceChange;
 extern int needsRefresh;
 extern int curMenuLocation;
 
-extern char* _menu_array[];
 extern file_handle curFile;
 extern file_handle curDir;
 extern char IPLInfo[256] __attribute__((aligned(32)));

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -810,7 +810,7 @@ void config_parse_global(char *configData) {
 					}
 				}
 				else if(!strcmp("DeviceSelectorType", name)) {
-					for(int i = 0; i < 2; i++) {
+					for(int i = 0; i < 3; i++) {
 						if(!strcmp(deviceSelectorTypesStr[i], value)) {
 							swissSettings.deviceSelectorType = i;
 							break;

--- a/cube/swiss/source/config/config.c
+++ b/cube/swiss/source/config/config.c
@@ -166,6 +166,7 @@ int config_update_global(bool checkConfigDevice) {
 	fprintf(fp, "IGRType=%s\r\n", igrTypeStr[swissSettings.igrType]);
 	fprintf(fp, "AVECompat=%s\r\n", aveCompatStr[swissSettings.aveCompat]);
 	fprintf(fp, "FileBrowserType=%s\r\n", fileBrowserStr[swissSettings.fileBrowserType]);
+	fprintf(fp, "DeviceSelectorType=%s\r\n", deviceSelectorTypesStr[swissSettings.deviceSelectorType]);
 	fprintf(fp, "BS2Boot=%s\r\n", bs2BootStr[swissSettings.bs2Boot]);
 	fprintf(fp, "FTPUserName=%s\r\n", swissSettings.ftpUserName);
 	fprintf(fp, "FTPPassword=%s\r\n", swissSettings.ftpPassword);
@@ -804,6 +805,14 @@ void config_parse_global(char *configData) {
 					for(int i = 0; i < 2; i++) {
 						if(!strcmp(fileBrowserStr[i], value)) {
 							swissSettings.fileBrowserType = i;
+							break;
+						}
+					}
+				}
+				else if(!strcmp("DeviceSelectorType", name)) {
+					for(int i = 0; i < 2; i++) {
+						if(!strcmp(deviceSelectorTypesStr[i], value)) {
+							swissSettings.deviceSelectorType = i;
 							break;
 						}
 					}

--- a/cube/swiss/source/gui/FrameBufferMagic.c
+++ b/cube/swiss/source/gui/FrameBufferMagic.c
@@ -1413,21 +1413,37 @@ static void _DrawMenuButtons(uiDrawObj_t *evt) {
 	
 	_DrawSimpleBox(19, 426, 602, 602, 0, fillColor, noColor);
 	
+	int btnBaseXOffset = 0, btnXOffset = 0, currentButton = 0, numButtons = 0;
+
+	if(swissSettings.deviceSelectorType == DEVICE_SELECTOR_DISABLED) {
+		btnBaseXOffset = BTN_BASE_XOFFSET_4BUTTONS;
+		btnXOffset 	   = BTN_XOFFSET_4BUTTONS;
+		numButtons 	   = 4;
+	} else {
+		btnBaseXOffset = BTN_BASE_XOFFSET_5BUTTONS;
+		btnXOffset 	   = BTN_XOFFSET_5BUTTONS;
+		numButtons 	   = 5;
+	}
+
 	// Highlight selected
 	int i;
-	for(i=0;i<5;i++)
+	for(i=0;i<numButtons;i++)
 	{
 		if(data->selection==i) 
-			_DrawImageNow(TEX_BTNHILIGHT, 48+(i*119), 428, BTNHILIGHT_WIDTH, BTNHILIGHT_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+			_DrawImageNow(TEX_BTNHILIGHT, btnBaseXOffset+(i*btnXOffset), 428, BTNHILIGHT_WIDTH, BTNHILIGHT_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
 	}
 
 	// Draw the buttons	
 	drawInit();
-	_DrawImageNow(TEX_BTNDEVICE, 48+(0*119)+BTNDEVICE_X, 428+BTNDEVICE_Y, BTNDEVICE_WIDTH, BTNDEVICE_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
-	_DrawImageNow(TEX_BTNSETTINGS, 48+(1*119)+BTNSETTINGS_X, 428+BTNSETTINGS_Y, BTNSETTINGS_WIDTH, BTNSETTINGS_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
-	_DrawImageNow(TEX_BTNINFO, 48+(2*119)+BTNINFO_X, 428+BTNINFO_Y, BTNINFO_WIDTH, BTNINFO_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
-	_DrawImageNow(TEX_BTNREFRESH, 48+(3*119)+BTNREFRESH_X, 428+BTNREFRESH_Y, BTNREFRESH_WIDTH, BTNREFRESH_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
-	_DrawImageNow(TEX_BTNEXIT, 48+(4*119)+BTNEXIT_X, 428+BTNEXIT_Y, BTNEXIT_WIDTH, BTNEXIT_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+
+	if(swissSettings.deviceSelectorType != DEVICE_SELECTOR_DISABLED) {
+		_DrawImageNow(TEX_BTNDEVICE, btnBaseXOffset+((currentButton++)*btnXOffset)+BTNDEVICE_X, 428+BTNDEVICE_Y, BTNDEVICE_WIDTH, BTNDEVICE_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+	}
+
+	_DrawImageNow(TEX_BTNSETTINGS, btnBaseXOffset+((currentButton++)*btnXOffset)+BTNSETTINGS_X, 428+BTNSETTINGS_Y, BTNSETTINGS_WIDTH, BTNSETTINGS_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+	_DrawImageNow(TEX_BTNINFO, btnBaseXOffset+((currentButton++)*btnXOffset)+BTNINFO_X, 428+BTNINFO_Y, BTNINFO_WIDTH, BTNINFO_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+	_DrawImageNow(TEX_BTNREFRESH, btnBaseXOffset+((currentButton++)*btnXOffset)+BTNREFRESH_X, 428+BTNREFRESH_Y, BTNREFRESH_WIDTH, BTNREFRESH_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
+	_DrawImageNow(TEX_BTNEXIT, btnBaseXOffset+((currentButton++)*btnXOffset)+BTNEXIT_X, 428+BTNEXIT_Y, BTNEXIT_WIDTH, BTNEXIT_HEIGHT, 0, 0.0f, 1.0f, 0.0f, 1.0f, 0);
 }
 
 // External

--- a/cube/swiss/source/gui/settings.c
+++ b/cube/swiss/source/gui/settings.c
@@ -52,7 +52,7 @@ static char *tooltips_global[PAGE_GLOBAL_MAX+1] = {
 	NULL,
 	"File Browser Type:\n\nStandard - Displays files with minimal detail (default)\n\nCarousel - Suited towards Game/DOL only use, consider combining\nthis option with the File Management setting turned off\nand Hide Unknown File Types turned on for a better experience.",
 	"File Management:\n\nWhen enabled, pressing Z on an entry in the file browser will allow it to be managed.",
-	"Device Selector:\n\nEnabled - Devices can be selected (default)\n\nShow Only - The current device is shown in the selector, and cannot be changed\n\nDisabled - The device selector will not appear",
+	"Device Selector:\n\nEnabled - Devices can be selected (default)\n\nShow Only - The current device is shown in the\nselector, and cannot be changed\n\nDisabled - The device selector will not appear and\nthe menu button will be removed",
 	"Recent List:\n\n(On) - Press Start while browsing to show a recent list.\n(Lazy) - Same as On but list updates only for new entries.\n(Off) - Recent list is completely disabled.\n\nThe lazy/off options exist to minimise SD card writes.",
 	NULL,
 	"Hide unknown file types:\n\nDisabled - Show all files (default)\nEnabled - Swiss will hide unknown file types from being displayed\n\nKnown file types are:\n GameCube Executables (.bin/.dol/.elf)\n Disc images (.gcm/.iso/.nkit.iso/.tgc)\n MP3 Music (.mp3)\n WASP/WKF Flash files (.fzn)\n GameCube Memory Card Files (.gci/.gcs/.sav)\n GameCube Executables with parameters appended (.dol+cli)",

--- a/cube/swiss/source/gui/settings.c
+++ b/cube/swiss/source/gui/settings.c
@@ -52,6 +52,7 @@ static char *tooltips_global[PAGE_GLOBAL_MAX+1] = {
 	NULL,
 	"File Browser Type:\n\nStandard - Displays files with minimal detail (default)\n\nCarousel - Suited towards Game/DOL only use, consider combining\nthis option with the File Management setting turned off\nand Hide Unknown File Types turned on for a better experience.",
 	"File Management:\n\nWhen enabled, pressing Z on an entry in the file browser will allow it to be managed.",
+	"Device Selector:\n\nEnabled - Devices can be selected (default)\n\nShow Only - The current device is shown in the selector, and cannot be changed\n\nDisabled - The device selector will not appear",
 	"Recent List:\n\n(On) - Press Start while browsing to show a recent list.\n(Lazy) - Same as On but list updates only for new entries.\n(Off) - Recent list is completely disabled.\n\nThe lazy/off options exist to minimise SD card writes.",
 	NULL,
 	"Hide unknown file types:\n\nDisabled - Show all files (default)\nEnabled - Swiss will hide unknown file types from being displayed\n\nKnown file types are:\n GameCube Executables (.bin/.dol/.elf)\n Disc images (.gcm/.iso/.nkit.iso/.tgc)\n MP3 Music (.mp3)\n WASP/WKF Flash files (.fzn)\n GameCube Memory Card Files (.gci/.gcs/.sav)\n GameCube Executables with parameters appended (.dol+cli)",
@@ -252,7 +253,7 @@ uiDrawObj_t* settings_draw_page(int page_num, int option, ConfigEntry *gameConfi
 		DrawAddChild(page, DrawLabel(page_x_ofs_key, 65, "Global Settings (1/5):"));
 		bool dbgEnable = devices[DEVICE_CUR] != &__device_usbgecko && deviceHandler_getDeviceAvailable(&__device_usbgecko);
 		// TODO settings to a new typedef that ties type etc all together, then draw a "page" of these rather than this at some point.
-		if(option < SET_STOP_MOTOR) {
+		if(option < SET_FLATTEN_DIR) {
 			drawSettingEntryString(page, &page_y_ofs, "System Sound:", swissSettings.sramStereo ? "Stereo":"Mono", option == SET_SYS_SOUND, true);
 			sprintf(sramHOffsetStr, "%+hi", swissSettings.sramHOffset);
 			drawSettingEntryString(page, &page_y_ofs, "Screen Position:", sramHOffsetStr, option == SET_SCREEN_POS, true);
@@ -261,11 +262,12 @@ uiDrawObj_t* settings_draw_page(int page_num, int option, ConfigEntry *gameConfi
 			drawSettingEntryString(page, &page_y_ofs, "Swiss Video Mode:", uiVModeStr[swissSettings.uiVMode], option == SET_SWISS_VIDEOMODE, true);
 			drawSettingEntryString(page, &page_y_ofs, "File Browser Type:", fileBrowserStr[swissSettings.fileBrowserType], option == SET_FILEBROWSER_TYPE, true);
 			drawSettingEntryBoolean(page, &page_y_ofs, "File Management:", swissSettings.enableFileManagement, option == SET_FILE_MGMT, true);
+			drawSettingEntryString(page, &page_y_ofs, "Device Selector:", deviceSelectorTypesStr[swissSettings.deviceSelectorType], option == SET_DEVICE_SELECTOR_TYPE, true);
 			drawSettingEntryString(page, &page_y_ofs, "Recent List:", recentListLevelStr[swissSettings.recentListLevel], option == SET_RECENT_LIST, true);
 			drawSettingEntryBoolean(page, &page_y_ofs, "Show hidden files:", swissSettings.showHiddenFiles, option == SET_SHOW_HIDDEN, true);
 			drawSettingEntryBoolean(page, &page_y_ofs, "Hide unknown file types:", swissSettings.hideUnknownFileTypes, option == SET_HIDE_UNK, true);
-			drawSettingEntryString(page, &page_y_ofs, "Flatten directory:", swissSettings.flattenDir, option == SET_FLATTEN_DIR, true);
 		} else {
+			drawSettingEntryString(page, &page_y_ofs, "Flatten directory:", swissSettings.flattenDir, option == SET_FLATTEN_DIR, true);
 			drawSettingEntryBoolean(page, &page_y_ofs, "Stop DVD Motor at startup:", swissSettings.stopMotor, option == SET_STOP_MOTOR, true);
 			drawSettingEntryString(page, &page_y_ofs, "SD/IDE Speed:", swissSettings.exiSpeed ? "32 MHz":"16 MHz", option == SET_EXI_SPEED, true);
 			drawSettingEntryString(page, &page_y_ofs, "AVE Compatibility:", aveCompatStr[swissSettings.aveCompat], option == SET_AVE_COMPAT, true);
@@ -492,6 +494,15 @@ void settings_toggle(int page, int option, int direction, ConfigEntry *gameConfi
 			break;
 			case SET_FILE_MGMT:
 				swissSettings.enableFileManagement ^=1;
+			break;
+			case SET_DEVICE_SELECTOR_TYPE:
+				swissSettings.deviceSelectorType += direction;
+				if(swissSettings.deviceSelectorType > 2) {
+					swissSettings.deviceSelectorType = 0;
+				}
+				if(swissSettings.deviceSelectorType < 0) {
+					swissSettings.deviceSelectorType = 2;
+				}
 			break;
 			case SET_RECENT_LIST:
 				swissSettings.recentListLevel += direction;

--- a/cube/swiss/source/gui/settings.c
+++ b/cube/swiss/source/gui/settings.c
@@ -42,6 +42,7 @@ char *fileBrowserStr[] = {"Standard", "Carousel"};
 char *bs2BootStr[] = {"No", "Yes", "Sound 1", "Sound 2"};
 char *sramLang[] = {"English", "German", "French", "Spanish", "Italian", "Dutch", "Japanese", "English (US)"};
 char *recentListLevelStr[] = {"Off", "Lazy", "On"};
+char *deviceSelectorTypesStr[] = {"Enabled", "Show Only", "Disabled"};
 
 static char *tooltips_global[PAGE_GLOBAL_MAX+1] = {
 	"System Sound:\n\nSets the default audio output type used by most games",

--- a/cube/swiss/source/gui/settings.h
+++ b/cube/swiss/source/gui/settings.h
@@ -28,6 +28,7 @@ enum SETTINGS_GLOBAL {
 	SET_SWISS_VIDEOMODE,
 	SET_FILEBROWSER_TYPE,
 	SET_FILE_MGMT,
+	SET_DEVICE_SELECTOR_TYPE,
 	SET_RECENT_LIST,
 	SET_SHOW_HIDDEN,
 	SET_HIDE_UNK,
@@ -149,6 +150,7 @@ extern char *aveCompatStr[];
 extern char *fileBrowserStr[];
 extern char *bs2BootStr[];
 extern char *recentListLevelStr[];
+extern char *deviceSelectorTypesStr[];
 #define SRAM_LANG_MAX 7
 extern char *sramLang[];
 int show_settings(int page, int option, ConfigEntry *config);

--- a/cube/swiss/source/images/buttons/btns.h
+++ b/cube/swiss/source/images/buttons/btns.h
@@ -1,6 +1,12 @@
 #ifndef BTNS_H
 #define BTNS_H
 
+// Button positioning constants
+#define BTN_BASE_XOFFSET_5BUTTONS (48)
+#define BTN_BASE_XOFFSET_4BUTTONS (64) // chosen completely arbitrarily
+#define BTN_XOFFSET_5BUTTONS (119) // floor(602/5)-1
+#define BTN_XOFFSET_4BUTTONS (149) // floor(602/4)-1
+
 // Buttons
 #define BTNSETTINGS_X       (18)
 #define BTNSETTINGS_Y        (3)

--- a/cube/swiss/source/main.c
+++ b/cube/swiss/source/main.c
@@ -162,6 +162,7 @@ int main(int argc, char *argv[])
 	swissSettings.aveCompat = 1;
 	swissSettings.enableFileManagement = 0;
 	swissSettings.recentListLevel = 2;
+	swissSettings.deviceSelectorType = DEVICE_SELECTOR_ENABLED;
 	Initialise();
 
 	needsDeviceChange = 1;

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2254,7 +2254,7 @@ void select_device(int type)
 			curDevice = 0;
 		}
 	}
-	
+
 	// return without prompting if the device selector is disabled
 	if(swissSettings.deviceSelectorType == DEVICE_SELECTOR_DISABLED) {
 		devices[type] = allDevices[curDevice];
@@ -2268,13 +2268,17 @@ void select_device(int type)
 		uiDrawObj_t *selectLabel = DrawStyledLabel(640/2, 195
 													, type == DEVICE_DEST ? "Destination Device" : "Device Selection"
 													, 1.0f, true, defaultColor);
-		uiDrawObj_t *fwdLabel = DrawLabel(520, 270, "->");
-		uiDrawObj_t *backLabel = DrawLabel(100, 270, "<-");
-		uiDrawObj_t *showAllLabel = DrawStyledLabel(20, 400, "(Z) Show all devices", 0.65f, false, showAllDevices ? defaultColor:deSelectedColor);
+
+		if(swissSettings.deviceSelectorType != DEVICE_SELECTOR_SHOW_ONLY) {
+			uiDrawObj_t *fwdLabel = DrawLabel(520, 270, "->");
+			uiDrawObj_t *backLabel = DrawLabel(100, 270, "<-");
+			uiDrawObj_t *showAllLabel = DrawStyledLabel(20, 400, "(Z) Show all devices", 0.65f, false, showAllDevices ? defaultColor:deSelectedColor);
+			DrawAddChild(deviceSelectBox, fwdLabel);
+			DrawAddChild(deviceSelectBox, backLabel);
+			DrawAddChild(deviceSelectBox, showAllLabel);
+		}
+
 		DrawAddChild(deviceSelectBox, selectLabel);
-		DrawAddChild(deviceSelectBox, fwdLabel);
-		DrawAddChild(deviceSelectBox, backLabel);
-		DrawAddChild(deviceSelectBox, showAllLabel);
 		
 		if(direction != 0) {
 			if(direction > 0) {
@@ -2308,7 +2312,7 @@ void select_device(int type)
 			DrawAddChild(deviceSelectBox, gameBootLabel);
 		}
 		// Memory card port devices, allow for speed selection
-		if(allDevices[curDevice]->location & (LOC_MEMCARD_SLOT_A | LOC_MEMCARD_SLOT_B | LOC_SERIAL_PORT_2)) {
+		if(swissSettings.deviceSelectorType != DEVICE_SELECTOR_SHOW_ONLY && allDevices[curDevice]->location & (LOC_MEMCARD_SLOT_A | LOC_MEMCARD_SLOT_B | LOC_SERIAL_PORT_2)) {
 			uiDrawObj_t *exiOptionsLabel = DrawStyledLabel(getVideoMode()->fbWidth-190, 400, "(X) EXI Options", 0.65f, false, inAdvanced ? defaultColor:deSelectedColor);
 			DrawAddChild(deviceSelectBox, exiOptionsLabel);
 			if(inAdvanced) {
@@ -2322,26 +2326,29 @@ void select_device(int type)
 			(PAD_BUTTON_RIGHT|PAD_BUTTON_LEFT|PAD_BUTTON_B|PAD_BUTTON_A|PAD_BUTTON_X|PAD_TRIGGER_Z) ))
 			{ VIDEO_WaitVSync (); }
 		u16 btns = padsButtonsHeld();
-		if((btns & PAD_BUTTON_X) && (allDevices[curDevice]->location & (LOC_MEMCARD_SLOT_A | LOC_MEMCARD_SLOT_B | LOC_SERIAL_PORT_2)))
-			inAdvanced ^= 1;
-		if(btns & PAD_TRIGGER_Z) {
-			showAllDevices ^= 1;
-			if(!showAllDevices && !deviceHandler_getDeviceAvailable(allDevices[curDevice])) {
-				inAdvanced = 0;
-				direction = 1;
+
+		if(swissSettings.deviceSelectorType != DEVICE_SELECTOR_SHOW_ONLY) {
+			if((btns & PAD_BUTTON_X) && (allDevices[curDevice]->location & (LOC_MEMCARD_SLOT_A | LOC_MEMCARD_SLOT_B | LOC_SERIAL_PORT_2)))
+				inAdvanced ^= 1;
+			if(btns & PAD_TRIGGER_Z) {
+				showAllDevices ^= 1;
+				if(!showAllDevices && !deviceHandler_getDeviceAvailable(allDevices[curDevice])) {
+					inAdvanced = 0;
+					direction = 1;
+				}
 			}
-		}
-		if(inAdvanced) {
-			if((btns & PAD_BUTTON_RIGHT) || (btns & PAD_BUTTON_LEFT)) {
-				swissSettings.exiSpeed^=1;
+			if(inAdvanced) {
+				if((btns & PAD_BUTTON_RIGHT) || (btns & PAD_BUTTON_LEFT)) {
+					swissSettings.exiSpeed^=1;
+				}
 			}
-		}
-		else {
-			if(btns & PAD_BUTTON_RIGHT) {
-				direction = 1;
-			}
-			if(btns & PAD_BUTTON_LEFT) {
-				direction = -1;
+			else {
+				if(btns & PAD_BUTTON_RIGHT) {
+					direction = 1;
+				}
+				if(btns & PAD_BUTTON_LEFT) {
+					direction = -1;
+				}
 			}
 		}
 			

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2461,12 +2461,25 @@ void menu_loop()
 				VIDEO_WaitVSync();
 			}
 			
-			if(btns & PAD_BUTTON_LEFT){	curMenuSelection = (--curMenuSelection < 0) ? (MENU_MAX-1) : curMenuSelection;}
-			else if(btns & PAD_BUTTON_RIGHT){curMenuSelection = (curMenuSelection + 1) % MENU_MAX;	}
+			// the curMenuSelection only knows about the index among all menu items, but the switch below wants
+			// this to map to a specific menu item ID. This variable holds the corrected menu item ID.
+			int menuItemSelection;
+
+			if(swissSettings.deviceSelectorType == DEVICE_SELECTOR_DISABLED) {
+				if(btns & PAD_BUTTON_LEFT){	curMenuSelection = (--curMenuSelection < 0) ? (MENU_MAX-2) : curMenuSelection;}
+				else if(btns & PAD_BUTTON_RIGHT){curMenuSelection = (curMenuSelection + 1) % (MENU_MAX-1);	}
+
+				menuItemSelection = curMenuSelection + 1;
+			} else {
+				if(btns & PAD_BUTTON_LEFT){	curMenuSelection = (--curMenuSelection < 0) ? (MENU_MAX-1) : curMenuSelection;}
+				else if(btns & PAD_BUTTON_RIGHT){curMenuSelection = (curMenuSelection + 1) % MENU_MAX;	}
+
+				menuItemSelection = curMenuSelection;
+			}
 
 			if(btns & PAD_BUTTON_A) {
 				//handle menu event
-				switch(curMenuSelection) {
+				switch(menuItemSelection) {
 					case MENU_DEVICE:
 						needsDeviceChange = 1;  //Change from SD->DVD or vice versa
 						break;

--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2255,6 +2255,11 @@ void select_device(int type)
 		}
 	}
 	
+	// return without prompting if the device selector is disabled
+	if(swissSettings.deviceSelectorType == DEVICE_SELECTOR_DISABLED) {
+		devices[type] = allDevices[curDevice];
+		return;
+	}
 	
 	uiDrawObj_t *deviceSelectBox = NULL;
 	while(1) {


### PR DESCRIPTION
This is a work in progress and I'm seeking feedback on a few things. Before I get to that, a quick explanation. In my feature request #720 (and to an extent some of the things asked for in #719), one of the things that keeps happening to us is that either accidentally or maliciously, someone will change the device off of SP2, and the system becomes "broken" until a staffer can investigate. Because this happens so often, the GameCube got moved as close as possible to the front counter of the museum. My goal is to eventually make all of the advanced features hidden behind a setting of some sort, and have an administrator bypass sort of function using PicoBoot. It turns out that PicoBoot will parse and pass arguments if you have e.g., `/ipl.cli`, and Swiss accepts all of the configuration options normally read from global.ini as arguments. This means that we could have `ipl.dol` and `start.dol` and the only difference be that `ipl.dol` has a restricted configuration passed via `ipl.cli`. Perfect. Now those options need to exist, and this is the first one I'm working on. This leads me to the things I'm looking for feedback on:

1. Are you happy with this direction, in general? I don't want to submit PRs to add features that annoy the team :).
2. How would you feel if I refactored how menu items work? I'm pretty unhappy with how I made the menu support 4 buttons, and I think that if I refactored it such that the menu is actually a list of structs, I can simplify the process of either adding or removing menu items in the future (which might also include switching menu items out for other menu items, as an example). One issue that I'll have to figure out with this is that the math for how the menu items are distributed and positioned on screen does not make a lot of sense to me.
3. Would it be a good idea to add a "UI Lockouts" page to settings?
4. Style-wise, do you prefer functions like `MenuItemNext()` or `menu_item_next()`? Both are used a lot in Swiss, and I don't know what the "current" pattern is.
5. Should I plan to get this PR ready as-is and redo the menus in a followup, or do that at the same time?


Currently identified stuff I still need to do:

* [ ] Get the 4-button alignment right; it's slightly too far to the right
* [ ] If you end up on the "file browser closed" state and then turn off the device selector, you're stuck unless you power-cycle the console or turn device selection back on, open the list, then turn it back off again.