### PR TITLE
Fix missing reset of served file in swissserver

### DIFF
--- a/cube/swiss/source/devices/usbgecko/usbgecko.c
+++ b/cube/swiss/source/devices/usbgecko/usbgecko.c
@@ -66,6 +66,8 @@ void usbgecko_lock_file(s32 lock) {
 		req.offset = 0;
 		req.size = 0;
 		usb_sendbuffer_safe(1, &req, sizeof(usb_data_req));
+		
+		served_file[0] = '\0';
 	}
 	else {
 		// Tell PC, I'm ready to read from a file


### PR DESCRIPTION
Fixes a crash of swissserver with message "Unknown reply from GC!" caused by served file not beeing reset after unlock of file.

To reproduce the issue run swissserver in a directory containing only a single game iso -> open the usbgecko in swiss -> exit back to the device selection -> open the usbgecko again