### PR TITLE
Build universal UF2 file for PicoBoot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,12 @@ package:   # create distribution package
 	@mv $(DIST)/GCLoader $(SVN_REVISION)
 	@mv $(DIST)/ISO $(SVN_REVISION)
 	@mv $(DIST)/MemoryCard $(SVN_REVISION)
-	@mv $(DIST)/PicoBoot $(SVN_REVISION)
 	@mv $(DIST)/USBGeckoRemoteServer $(SVN_REVISION)
 	@mv $(DIST)/Wii $(SVN_REVISION)
 	@mv $(DIST)/WiikeyFusion $(SVN_REVISION)
 	@mv $(DIST)/WODE $(SVN_REVISION)
+	@mkdir $(SVN_REVISION)/PicoBoot
+	@cp $(DIST)/PicoBoot/$(SVN_REVISION).uf2 $(SVN_REVISION)/PicoBoot/$(SVN_REVISION).uf2
 	@find ./$(SVN_REVISION) -type f -print0 | xargs -0 sha256sum > $(SVN_REVISION).sha256
 	@mv $(SVN_REVISION).sha256 $(SVN_REVISION)
 	@git log -n 4 > $(SVN_REVISION)-changelog.txt
@@ -166,7 +167,9 @@ build-ipl:
 	@mkdir $(DIST)/Apploader/swiss/patches
 	@mkdir $(DIST)/PicoBoot
 	@$(DOL2IPL) $(DIST)/Apploader/swiss/patches/apploader.img $(PACKER)/reboot.dol *$(SVN_REVISION).dol
-	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION).uf2 $(PACKER)/reboot.dol
+	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION)_pico.uf2 $(PACKER)/reboot.dol rp2040
+	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION)_pico2.uf2 $(PACKER)/reboot.dol rp2350
+	@cat $(DIST)/PicoBoot/$(SVN_REVISION)_pico.uf2 $(DIST)/PicoBoot/$(SVN_REVISION)_pico2.uf2 > $(DIST)/PicoBoot/$(SVN_REVISION).uf2
 
 #------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,11 @@ package:   # create distribution package
 	@mv $(DIST)/GCLoader $(SVN_REVISION)
 	@mv $(DIST)/ISO $(SVN_REVISION)
 	@mv $(DIST)/MemoryCard $(SVN_REVISION)
+	@mv $(DIST)/PicoBoot $(SVN_REVISION)
 	@mv $(DIST)/USBGeckoRemoteServer $(SVN_REVISION)
 	@mv $(DIST)/Wii $(SVN_REVISION)
 	@mv $(DIST)/WiikeyFusion $(SVN_REVISION)
 	@mv $(DIST)/WODE $(SVN_REVISION)
-	@mkdir $(SVN_REVISION)/PicoBoot
-	@cp $(DIST)/PicoBoot/$(SVN_REVISION).uf2 $(SVN_REVISION)/PicoBoot/$(SVN_REVISION).uf2
 	@find ./$(SVN_REVISION) -type f -print0 | xargs -0 sha256sum > $(SVN_REVISION).sha256
 	@mv $(SVN_REVISION).sha256 $(SVN_REVISION)
 	@git log -n 4 > $(SVN_REVISION)-changelog.txt
@@ -167,9 +166,7 @@ build-ipl:
 	@mkdir $(DIST)/Apploader/swiss/patches
 	@mkdir $(DIST)/PicoBoot
 	@$(DOL2IPL) $(DIST)/Apploader/swiss/patches/apploader.img $(PACKER)/reboot.dol *$(SVN_REVISION).dol
-	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION)_pico.uf2 $(PACKER)/reboot.dol rp2040
-	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION)_pico2.uf2 $(PACKER)/reboot.dol rp2350
-	@cat $(DIST)/PicoBoot/$(SVN_REVISION)_pico.uf2 $(DIST)/PicoBoot/$(SVN_REVISION)_pico2.uf2 > $(DIST)/PicoBoot/$(SVN_REVISION).uf2
+	@$(DOL2IPL) $(DIST)/PicoBoot/$(SVN_REVISION).uf2 $(PACKER)/reboot.dol
 
 #------------------------------------------------------------------
 


### PR DESCRIPTION
PicoBoot is now compatible with Pico 2 boards thanks to https://github.com/webhdx/PicoBoot/pull/129 This requires new payload UF2 files to be created. A nice thing about Pico and UF2 is that we can have a single UF2 file with blocks targeted at different MCUs. It lets us create a single gekkoboot payload compatible with both Pico and Pico 2 boards.