### PR TITLE
EMU_MEMCARD requires BS2 init for OSLoMem & EXI

### DIFF
--- a/cube/swiss/source/swiss.c
+++ b/cube/swiss/source/swiss.c
@@ -2173,7 +2173,7 @@ void load_game() {
 				break;
 			}
 		}
-		if(swissSettings.bs2Boot) {
+		if(swissSettings.bs2Boot || (devices[DEVICE_CUR]->emulated() & EMU_MEMCARD)) {
 			fileToPatch = &filesToPatch[numToPatch++];
 			strcpy(fileToPatch->name, "BS2.img");
 			fileToPatch->type = PATCH_BS2;


### PR DESCRIPTION
**no longer contributing**