### PR TITLE
Allow commas in .dcp param values

### DIFF
--- a/cube/swiss/source/config/dolparameters.c
+++ b/cube/swiss/source/config/dolparameters.c
@@ -59,7 +59,17 @@ void parseParameterValue(char *tuple, ParameterValue* val) {
 	char* valEnd = NULL;
 	
 	// Check for a key and for a value
-	if((keyStart=strchr(tuple, '{'))!=NULL && (keyEnd=strchr(keyStart, ','))!=NULL) {
+	if((keyStart=strchr(tuple, '{'))!=NULL) {
+		// Find the closing brace to bound our search
+		char* closingBrace = strchr(keyStart, '}');
+		if(closingBrace == NULL) return;
+		
+		// Find the last comma before the closing brace
+		keyEnd = closingBrace - 1;
+		while(keyEnd > keyStart && *keyEnd != ',') keyEnd--;
+		
+		if(*keyEnd != ',') return; // malformed input
+		
 		// Trim whitespace
 		keyStart++;
 		while(*keyStart==' ') keyStart++;


### PR DESCRIPTION
Simple change that allows for values in .dcp files to have commas in them, making lines like the following valid and parsable:

```
Name={--palette, Palette}
Values={#84E1,#9986,#C6A1,#CEE1, DMG (NSO)}, {#8464,#99AA,#C70E,#F3FA, DMG (BGB)}
```

Current behaviour:
```
[0] arg value="--palette"  name="Palette"
    [0] value="#84E1"  name="#9986,#C6A1,#CEE1, DMG (NSO)"
    [1] value="#8464"  name="#99AA,#C70E,#F3FA, DMG (BGB)"
```

Fix:
```
[0] arg value="--palette"  name="Palette"
    [0] value="#84E1,#9986,#C6A1,#CEE1"  name="DMG (NSO)"
    [1] value="#8464,#99AA,#C70E,#F3FA"  name="DMG (BGB)"
```