### PR TITLE
Change FTP command from 'LIST -al' to 'LIST'

### DIFF
--- a/cube/swiss/source/devices/ftp/ftp_devoptab.c
+++ b/cube/swiss/source/devices/ftp/ftp_devoptab.c
@@ -1368,7 +1368,7 @@ loaddir_retry:
 		return false;
 	}
 
-	res = ftp_execute_open(env, "LIST -al", "A", 0, &data_sock);
+	res = ftp_execute_open(env, "LIST", "A", 0, &data_sock);
 	if(res < 0)
 	{
 		return false;


### PR DESCRIPTION
Swiss currently sends LIST -al, which relies on the server accepting Unix ls options. FTP does not standardize those options; LIST takes an optional pathname (So, some may think -al is a directory). Complies to [RFC 959](https://datatracker.ietf.org/doc/html/rfc959)

This addresses the reproducible 550 command incompatibility. It does not claim to resolve the subsequently reported wait after bare LIST (Issue #1015 ) with Firezilla; that behavior requires further investigation.