### PR TITLE
Fix FTP REST offsets above 999,999,999 bytes

### DIFF
--- a/cube/swiss/source/devices/ftp/ftp_devoptab.c
+++ b/cube/swiss/source/devices/ftp/ftp_devoptab.c
@@ -835,7 +835,10 @@ execute_open_actv_retry:
 
 			NET_PRINTF("offset=%u:%u\n", (u32)(offset >> 32), (u32)(offset & 0xffffFFFF));
 
-			sprintf(buf, "REST %u%u", high_part, low_part );
+			if (high_part)
+				sprintf(buf, "REST %u%09u", high_part, low_part);
+			else
+				sprintf(buf, "REST %u", low_part);
 			NET_PRINTF("REST=%s\n",buf);
 			if((res = ftp_execute(env, buf, 350, 1)) < 0)
 			{
@@ -1043,7 +1046,10 @@ execute_open_retry:
 
 			NET_PRINTF("offset=%u:%u\n", (u32)(offset >> 32), (u32)(offset & 0xffffFFFF));
 
-			sprintf(buf, "REST %u%u", high_part, low_part );
+			if (high_part)
+				sprintf(buf, "REST %u%09u", high_part, low_part);
+			else
+				sprintf(buf, "REST %u", low_part);
 			NET_PRINTF("REST=%s\n",buf);
 			if((res = ftp_execute(env, buf, 350, 1)) < 0)
 			{

--- a/cube/swiss/source/devices/ftp/ftp_devoptab.c
+++ b/cube/swiss/source/devices/ftp/ftp_devoptab.c
@@ -828,17 +828,7 @@ execute_open_actv_retry:
 
 		if ( offset!=0 )
 		{
-			//2^32 = 4.294.967.296
-
-			u32 low_part = offset % 1000000000;
-			u32 high_part = offset / 1000000000;
-
-			NET_PRINTF("offset=%u:%u\n", (u32)(offset >> 32), (u32)(offset & 0xffffFFFF));
-
-			if (high_part)
-				sprintf(buf, "REST %u%09u", high_part, low_part);
-			else
-				sprintf(buf, "REST %u", low_part);
+			sprintf(buf, "REST %lld", offset);
 			NET_PRINTF("REST=%s\n",buf);
 			if((res = ftp_execute(env, buf, 350, 1)) < 0)
 			{
@@ -1041,15 +1031,7 @@ execute_open_retry:
 
 		if( offset !=0 )
 		{
-			u32 low_part = offset % 1000000000;
-			u32 high_part = offset / 1000000000;
-
-			NET_PRINTF("offset=%u:%u\n", (u32)(offset >> 32), (u32)(offset & 0xffffFFFF));
-
-			if (high_part)
-				sprintf(buf, "REST %u%09u", high_part, low_part);
-			else
-				sprintf(buf, "REST %u", low_part);
+			sprintf(buf, "REST %lld", offset);
 			NET_PRINTF("REST=%s\n",buf);
 			if((res = ftp_execute(env, buf, 350, 1)) < 0)
 			{


### PR DESCRIPTION
Zero pad the lower decimal chunk when constructing REST offsets above 999,999,999 bytes.

The existing code splits large offsets into base 1,000,000,000 chunks, but concatenates the lower chunk without padding. This can produce an incorrect REST argument when the lower chunk has fewer than nine decimal digits.

For example, 1,050,000,000 currently becomes:
`REST 150000000`
instead of:
`REST 1050000000`

This preserves the existing large-offset handling and applies the fix to both active and passive FTP paths.

A future change _might_ be able to format the 64-bit offset directly and remove the chunk concatenation entirely. But would need to do more digging before doing that.